### PR TITLE
Remove searx.hlfh.space

### DIFF
--- a/searxinstances/instances.yml
+++ b/searxinstances/instances.yml
@@ -122,7 +122,6 @@ https://searx.handskemager.xyz:
   additional_urls:
     http://searx.ecpuepfcd3nekvh2.onion/: Hidden Service
 https://searx.hardwired.link: {}
-https://searx.hlfh.space: {}
 https://searx.info:
   comments:
   - Strange searxspm cookie on every page. tracking?


### PR DESCRIPTION
My instance IP address has been banned by eTools search engine. 
I am now testing a fully private instance, and eTools works.
Therefore, I am removing searx.hlfh.space instance.